### PR TITLE
Making the script robust to non scheduled talks

### DIFF
--- a/scripts/generate_session_tweet_csv.py
+++ b/scripts/generate_session_tweet_csv.py
@@ -71,12 +71,13 @@ def generate_row(session, track, speakers, template=None):
     photos = list(filter(bool, map(lambda sp: sp['attributes']['photo-url'], speakers)))
 
     starts_at = session['attributes']['starts-at']
-    starts_at_time = parser.parse(starts_at).astimezone(timezone) - delta
+    if starts_at: 
+        starts_at_time = parser.parse(starts_at).astimezone(timezone) - delta
 
     return (
         text,
         photos[0] if photos else None,
-        starts_at_time.strftime('%Y-%m-%d %H:%M'),
+        starts_at_time.strftime('%Y-%m-%d %H:%M') if starts_at else None,
     )
 
 


### PR DESCRIPTION
Issue: 
When a talk isn't scheduled, the start time of the talk is not available, and therefore the script get a `None` on the `start_time`.

Solution: 
To fix this issue, we're only going to parsing the time when the time is not `None`. By adding this check for None values in the `start_time` field, the script will be able to handle cases where talks are not scheduled and avoid errors related to parsing missing or incorrect data.